### PR TITLE
[Jules] feat: Add new post on using news in investing

### DIFF
--- a/_portfolio/2024-07-18-news-investing-guide.md
+++ b/_portfolio/2024-07-18-news-investing-guide.md
@@ -1,0 +1,117 @@
+---
+title: "From Headlines to Holdings: A Practical Guide to Using News in Your Investment Strategy"
+excerpt: "Learn how to cut through the noise of financial news and use real-time information to make smarter, more confident investment decisions. This is how our platform helps you stay ahead."
+date: 2024-07-18
+collection: portfolio
+tags: [news, investing, strategy, data, decision-making, behavioral-finance]
+---
+
+### Executive summary 🚦
+- News drives markets, but headlines can be misleading and trigger emotional decisions. The key is to separate the signal from the noise.
+- A disciplined framework—verifying news with data, understanding market context, and focusing on long-term themes—is critical for success.
+- This platform provides curated insights and direct access to high-quality data, helping you build a robust, news-aware investment process.
+- **Strategy:** Focus on credible data over narratives, use volatility as an opportunity, and align news-driven trades with your core portfolio strategy.
+
+---
+
+### 1) The Double-Edged Sword of Financial News 📰⚔️
+Financial news is the lifeblood of markets, providing a constant stream of information that shapes asset prices. However, not all news is created equal, and our reaction to it is often more important than the news itself.
+
+**Why News Moves Markets:**
+- **New Information:** A surprise inflation print, an unexpected earnings report, or a geopolitical event forces a repricing of assets.
+- **Sentiment Shifts:** Fear and greed are powerful forces. A scary headline can trigger a sell-off even if the underlying fundamentals haven't changed.
+
+**The Danger of Noise and Behavioral Biases:**
+- **Confirmation Bias:** We tend to favor information that confirms our existing beliefs. If you're bullish on a stock, you'll likely focus on positive news and ignore negative signals.
+- **Recency Bias:** We often over-weight recent events, assuming current trends will continue indefinitely.
+- As Nobel laureate Daniel Kahneman noted, the human mind is prone to making fast, intuitive judgments that can be disastrous in investing.
+  Source: [Thinking, Fast and Slow](https://us.macmillan.com/books/9780374533557/thinkingfastandslow){:target="_blank" rel="noopener"}
+
+---
+
+### 2) A Framework for Analyzing News 🛠️🧠
+To use news effectively, you need a system. Here is a practical, four-step framework:
+
+**Step 1: Identify the Source and Credibility**
+- Is the source a primary document (e.g., a company's SEC filing, a BLS data release) or a third-party interpretation? Primary sources are always better.
+- Be wary of sensationalism. Look for neutral, data-driven reporting.
+
+**Step 2: Connect to Macro Themes**
+- How does this piece of news fit into the bigger picture? Is it related to one of the key macro drivers?
+  - **Inflation:** Is it getting hotter or colder? (Affects Fed policy)
+  - **Economic Growth:** Is the economy accelerating or decelerating? (Affects corporate earnings)
+  - **Monetary Policy:** What is the central bank likely to do next?
+- For example, a single company's weak earnings report is one data point. A string of weak reports in the same sector could signal a broader economic slowdown.
+
+**Step 3: Quantify the Impact with Data**
+- **Never take a headline at face value.** Verify the narrative with hard data.
+- If news reports "surging jobless claims," check the official data from the Department of Labor. Is it a one-week blip or a sustained trend?
+  Source: [Department of Labor - Unemployment Insurance Weekly Claims](https://www.dol.gov/ui/data.pdf){:target="_blank" rel="noopener"}
+- This is where having direct access to data sources like FRED is invaluable.
+
+**Step 4: Assess Market Expectations**
+- The market is a discounting mechanism. Is this news already "priced in"?
+- An earnings beat doesn't guarantee a stock will go up. If expectations were even higher, the stock could fall.
+- The Citi Economic Surprise Index (CESI) is a great tool for this. It measures where economic data is coming in relative to consensus forecasts.
+  Source: [Citigroup - Economic Surprise Index](https://www.citivelocity.com/citigps/report/VI20230221050000/){:target="_blank" rel="noopener"} (Note: Often requires a subscription, but many research providers quote it.)
+
+---
+
+### Case Study: Navigating the COVID-19 Crash (March 2020) 📈📉
+Let's apply our framework to a real, historic event: the market crash at the onset of the COVID-19 pandemic.
+
+**1. The News & The Panic (Late Feb – Mid-March 2020)**
+- **Headlines:** The news was dire. "Global Pandemic Declared," "Economies Shut Down," "Historic Market Plunge." Fear was everywhere. The S&P 500 fell over 30% in a matter of weeks.
+- **The Noise:** The daily headlines created a narrative of unending economic winter. The impulse was to sell everything.
+
+**2. Applying the Framework**
+- **Source & Credibility:** The news came from primary sources like the World Health Organization (WHO) and government press conferences. It was highly credible.
+- **Connect to Macro Themes:** This was a textbook exogenous shock, hitting both economic supply (factories closing) and demand (consumers staying home). The key question was: what would the policy response be?
+- **Quantify the Impact with Data:**
+    - **The Bad:** Jobless claims skyrocketed to unprecedented levels, confirming the economic damage. Source: [FRED - Initial Claims (ICSA)](https://fred.stlouisfed.org/series/ICSA){:target="_blank" rel="noopener"}.
+    - **The Signal:** Amidst the panic, the crucial data point was the policy response. On March 23, 2020, the U.S. Federal Reserve announced "extensive new measures to support the economy," including unlimited quantitative easing. This was a signal that they would do "whatever it takes" to ensure markets continued to function. Source: [Federal Reserve Press Release](https://www.federalreserve.gov/newsevents/pressreleases/monetary20200323b.htm){:target="_blank" rel="noopener"}.
+- **Assess Market Expectations:** The market had priced in a depression. The Fed's massive intervention was far beyond what was expected and changed the entire calculus.
+
+**3. The Outcome**
+- The market bottomed on the very day of the Fed's announcement, March 23, 2020.
+- Investors who panicked and sold near the lows locked in devastating losses.
+- Those who understood that the policy signal was more important than the headline noise were able to ride the historic recovery that followed.
+
+This case study proves the value of a disciplined framework. By looking past the scary headlines to the underlying policy data, an investor could have avoided a catastrophic mistake and even found a generational buying opportunity.
+
+---
+
+### 3) How We Help You Stay Ahead 🎯
+Our goal is to empower you to make smarter decisions by providing the tools you need to apply this framework.
+
+- **Curated News & Insights:** We filter out the noise and highlight what's truly moving markets.
+- **Integrated Data Dashboards:** You don't have to hunt for charts. We bring the data to you, right alongside the news.
+- **Educational Content:** Posts like this one are designed to help you build the skills to become a better investor.
+
+---
+
+### 4) Chart Pack: Your News Verification Toolkit 🗺️
+Use these live charts to ground your news analysis in data.
+
+- **Market Fear Gauge (VIX):** Is the market complacent or panicked? High VIX readings often coincide with scary headlines and potential buying opportunities.
+  [![VIX](https://fred.stlouisfed.org/graph/fredgraph.png?id=VIXCLS)](https://fred.stlouisfed.org/series/VIXCLS){:target="_blank" rel="noopener"}
+
+- **Consumer Confidence (UMCSENT):** How is the consumer feeling? This is a key leading indicator for consumer spending, which drives ~70% of the US economy.
+  [![Consumer Sentiment](https://fred.stlouisfed.org/graph/fredgraph.png?id=UMCSENT)](https://fred.stlouisfed.org/series/UMCSENT){:target="_blank" rel="noopener"}
+
+- **Inflation Expectations (MICH):** Where do consumers think inflation is headed? This can become a self-fulfilling prophecy and is watched closely by the Fed.
+  [![Inflation Expectations](https.stlouisfed.org/graph/fredgraph.png?id=MICH)](https://fred.stlouisfed.org/series/MICH){:target="_blank" rel="noopener"}
+
+- **Treasury Yield Curve (T10Y2Y):** The spread between the 10-year and 2-year Treasury yields is a classic recession indicator. An inverted curve (short-term rates higher than long-term rates) has preceded every US recession for the past 50 years.
+  [![Yield Curve](httpshttps://fred.stlouisfed.org/graph/fredgraph.png?id=T10Y2Y)](https://fred.stlouisfed.org/series/T10Y2Y){:target="_blank" rel="noopener"}
+
+Tip: Click any chart to open it on FRED and explore the data for yourself.
+
+---
+
+### 5) What to Watch Next 👀⏱️
+- **Upcoming Data:** Always be aware of the economic calendar. Key releases include the CPI (inflation), the monthly jobs report (Nonfarm Payrolls), and retail sales.
+- **Sentiment Indicators:** Keep an eye on the VIX and consumer confidence.
+- **Fed Speak:** Pay attention to what Fed officials are saying. Their language can provide clues about future policy.
+
+By building a disciplined process for consuming and analyzing news, you can turn what is often a source of anxiety into a powerful tool for building wealth.


### PR DESCRIPTION
This commit adds a new blog post to the finance and investment section. The post is titled "From Headlines to Holdings: A Practical Guide to Using News in Your Investment Strategy".

It provides a guide on how to analyze financial news, including a framework for analysis and a chart pack with live data from FRED. The post is created with a past date to backfill content.

Revision: Adds a case study on the COVID-19 market crash to provide a real-world example of the framework in action.