### PR TITLE
[Jules] feat: Add blog post on GLP-1 drugs

### DIFF
--- a/_life/2025-08-11-the-revolution-of-weight-loss-drugs.md
+++ b/_life/2025-08-11-the-revolution-of-weight-loss-drugs.md
@@ -1,0 +1,79 @@
+---
+title: "The Weight Loss Revolution: Unpacking the Science and Stocks Behind GLP-1 Drugs"
+date: 2025-08-11
+author: "Name Name"
+---
+
+## Introduction: A Paradigm Shift in Weight Management
+
+It’s impossible to ignore the conversation that has dominated health forums, social media feeds, and even celebrity gossip columns for the past few years: a new class of drugs that seems to melt away pounds with once-a-week injections. Names like Ozempic and Wegovy have become household terms, synonymous with a level of weight loss previously thought impossible without surgery.
+
+But this is far more than a Hollywood trend. We are witnessing a paradigm shift in how the medical community and society at large approach obesity. These drugs, known as GLP-1 receptor agonists, represent a scientific breakthrough that is not only transforming the treatment of Type 2 diabetes but is now tackling one of the most complex and persistent health crises of our time: obesity.
+
+The implications are staggering. For the first time, a medication offers a tool that can genuinely move the needle on a condition affecting over a billion people worldwide. This has, in turn, ignited a fierce corporate rivalry between pharmaceutical titans, sent stock markets on a rollercoaster ride, and created a ripple effect that could reshape industries from food and beverage to apparel. This post will unpack the science behind these "miracle" drugs, analyze the high-stakes business battle, and explore the long-term investment landscape of a market that is just getting started.
+
+## The Science of Satiety: How Do These "Miracle" Drugs Work?
+
+To understand the power of drugs like semaglutide (the active ingredient in Ozempic and Wegovy), we first need to understand a powerful natural hormone our bodies produce: Glucagon-Like Peptide-1 (GLP-1).
+
+GLP-1 is an **incretin hormone**, which is released from our small intestine when we eat. It's a key player in the complex signaling system that manages our blood sugar and appetite. Think of it as the body's natural "I'm full and satisfied" signal. GLP-1 receptor agonists are essentially a synthetic, long-lasting version of this hormone. When you take a drug like semaglutide, it binds to the same receptors as your natural GLP-1 and turns up the volume on its effects.
+
+These effects are four-fold, creating a powerful combination for both blood sugar control and weight loss:
+
+1.  **It Stimulates Insulin Release:** GLP-1 tells the pancreas to release insulin after you eat. Insulin is the key that allows glucose (sugar) from your blood to enter your cells to be used for energy, thereby lowering your blood sugar.
+2.  **It Suppresses Glucagon Secretion:** Glucagon is another hormone from the pancreas, but it does the opposite of insulin—it tells the liver to release stored sugar into the bloodstream. By blocking glucagon, GLP-1 prevents your body from adding unnecessary sugar to your system.
+3.  **It Slows Digestion:** GLP-1 slows down "gastric emptying," the process of food moving from your stomach to your intestines. When your stomach stays fuller for longer, you feel physically satisfied and are less likely to overeat.
+4.  **It Signals Fullness to the Brain:** This is perhaps the most revolutionary aspect for weight loss. GLP-1 directly targets the hypothalamus in the brain, the area that controls hunger and satiety. It effectively tells your brain that you're full, reducing cravings and the desire to eat.
+
+The clinical results of this multi-pronged attack are undeniable. A large-scale meta-analysis of 47 randomized controlled trials, published in the journal *Diabetes Care*, confirmed the significant efficacy of these drugs. The study, which included over 23,000 patients, found that GLP-1 agonists led to substantial reductions in weight, BMI, and waist circumference when compared to a placebo. You can review the findings of this landmark study [here](https://doi.org/10.2337/dc24-1678).
+
+## The Titans of Transformation: Novo Nordisk vs. Eli Lilly
+
+The race to dominate this burgeoning market has created a head-to-head battle between two pharmaceutical giants:
+
+*   **Novo Nordisk:** A Danish company with a long history in diabetes care, Novo Nordisk was the first to realize the massive potential of GLP-1s for weight loss. They market semaglutide as **Ozempic** for Type 2 diabetes and in a higher dose as **Wegovy** specifically for obesity.
+*   **Eli Lilly:** An American pharmaceutical powerhouse, Eli Lilly entered the fray with a next-generation drug called tirzepatide, marketed as **Mounjaro** for diabetes and **Zepbound** for weight loss. Tirzepatide is a dual-action agonist, targeting both the GLP-1 and GIP (glucose-dependent insulinotropic polypeptide) receptors, another incretin hormone. This dual action has, in some studies, shown to be even more effective for weight loss than GLP-1 alone.
+
+This rivalry is not just about market share; it's a high-stakes chess match involving clinical trials, marketing, manufacturing capacity, and a race for the next big innovation.
+
+## Market Mania and Meltdown: The "Commotion Burden" and a Stock's Steep Fall
+
+For a period, Novo Nordisk could do no wrong. From mid-2022 through the summer of 2024, its stock was on a historic tear, fueled by insatiable demand for Ozempic and Wegovy. The company's success was so immense that it became the largest company in Europe by market capitalization, its value surpassing the entire GDP of its home country of Denmark.
+
+But what goes up can come down. In August 2025, the market darling experienced a shocking meltdown. **Novo Nordisk's shares plummeted by over 23% in a single week**, wiping out approximately €60 billion in valuation. This wasn't a random market fluctuation; it was a response to the company issuing a stark profit warning, signaling a drop in its full-year sales and profit forecasts.
+
+This event laid bare the "commotion burden" that Novo Nordisk and, to some extent, the entire sector faces:
+
+*   **Fierce Competition:** The primary driver of Novo's woes was the stunning success of Eli Lilly's Zepbound and Mounjaro. Clinical data and anecdotal reports suggested that Lilly's dual-agonist was not only more effective for weight loss but might also have a more tolerable side-effect profile for some patients. The market is no longer a one-horse race.
+*   **The Threat of Generics:** While the patents for these specific drugs are years from expiring, the pharmaceutical industry is always under pressure from generic drug manufacturers looking to create "copycat" versions or challenge patents in court. This long-term threat always looms over blockbuster drugs.
+*   **Safety, Side Effects, and Stigma:** The most common side effects of GLP-1s are gastrointestinal—nausea, diarrhea, and vomiting are widely reported. While often manageable, they can be severe enough for patients to stop treatment. More concerning are the rare but serious risks flagged by regulators, including a potential for pancreatitis and a black box warning for a type of thyroid cancer (medullary thyroid carcinoma) seen in animal studies. Furthermore, the discussion around "Ozempic face" (facial aging from rapid weight loss) and concerns about the loss of lean muscle mass alongside fat have added to the public relations challenges.
+*   **Cost and Insurance Hurdles:** These drugs are expensive, often costing over $1,000 a month without insurance in the U.S. This has led to a major battle with insurance companies, many of whom are reluctant to cover the medications for obesity, viewing it as a "lifestyle" treatment rather than a medical necessity. This limits the accessible market significantly.
+
+## A Long-Term Bet on a Shrinking Waistline? Investment Perspectives
+
+Despite the volatility and challenges, the long-term investment case for the obesity drug market remains incredibly compelling. A recent report from Morgan Stanley projects that the global market could soar from about $15 billion in 2024 to **$150 billion by 2035**.
+
+So, what are the key factors an investor should consider?
+
+**The Bull Case: Key Growth Drivers**
+
+1.  **Expanded Indications - The Game Changer:** The true potential of these drugs may have little to do with waistlines and everything to do with hearts, kidneys, and livers. Recent studies have shown that GLP-1s can significantly reduce the risk of heart attacks, strokes, and kidney disease progression. As these drugs gain approval for treating these critical co-morbidities, they shift from being a "lifestyle" drug to an essential, life-saving therapy that insurers will have a much harder time denying.
+2.  **The Holy Grail: An Oral Pill:** The need for weekly injections is a significant barrier for many potential users. The company that perfects a safe, effective, and affordable oral version (a pill) will unlock a massive segment of the market. Eli Lilly has already shown promising data for its oral drug, `orforglipron`, and Novo Nordisk is racing to develop its own. This is a key area to watch.
+3.  **Global Expansion:** The U.S. is currently the biggest market, but it's just the tip of the iceberg. As manufacturing capacity ramps up and prices potentially come down, the international market, particularly in Europe and Asia, represents a vast, untapped opportunity.
+4.  **The Ripple Effect:** The widespread use of these drugs could have a profound impact on other industries. For an investor, this creates a secondary field of opportunities and risks:
+    *   **Potential Losers:** Companies that rely on high-calorie, processed food and sugary beverage consumption could face headwinds. This includes fast-food chains, snack makers, and soda companies.
+    *   **Potential Winners:** The apparel industry could see a boom as millions of people need to refresh their wardrobes. Fitness companies, nutritional supplement providers, and wellness services could also benefit from a population that is more engaged with their health.
+
+**Investment Considerations**
+
+When evaluating the companies in this space, it's no longer enough to look at sales figures. An informed investor should be asking:
+*   What does their R&D pipeline look like? Are they developing oral versions, next-generation molecules, or combination therapies?
+*   How are they addressing the manufacturing and supply chain challenges?
+*   What is their strategy for securing broader insurance coverage and expanding into global markets?
+*   How are they positioned to compete not just for the next quarter, but for the next decade?
+
+## Conclusion: The Future is Lighter, But Not Without Its Baggage
+
+The rise of GLP-1 agonists is one of the most exciting medical and financial stories of our time. It represents a genuine breakthrough in public health, offering a powerful tool against the chronic disease of obesity and its related conditions.
+
+However, the path forward is complex. The journey from a blockbuster drug to a long-term, sustainable franchise is fraught with intense competition, regulatory hurdles, and public perception challenges. The story of Novo Nordisk's stock illustrates this perfectly: incredible success can quickly be tempered by the harsh realities of the market. For investors, the opportunity is immense, but it requires a deep understanding of the science, the competitive landscape, and the long-term trends that will shape this revolutionary new era of medicine.


### PR DESCRIPTION
This commit adds a new long-form blog post to the 'life and interests' section about the science and financial landscape of GLP-1 weight loss drugs like semaglutide.

The post covers:
- The scientific mechanism of GLP-1 agonists.
- The corporate rivalry between Novo Nordisk and Eli Lilly.
- An analysis of market trends and a specific stock drop event.
- A discussion of long-term investment considerations.
- A hyperlink to a scientific meta-analysis is included as a source.